### PR TITLE
Fix bin/install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python -u -m pipz --install $*
+python -u -m pipz $*


### PR DESCRIPTION
There was an extra option `--install` that shouldn't be there (in the
Windows install.bat it's also not there). As far as I could tell this is
actually passed as a package name which makes for a faulty pip command:
`pip install (...) --install package_a package_b`.