### PR TITLE
Fix #11, support preprocessing

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,5 +1,5 @@
 name = "pipz"
-version = "1.1.10"
+version = "1.2.0"
 requires = ["bleeding_rez-2.29+", "python>=2,<4"]
 
 tools = [

--- a/python/pipz/cli.py
+++ b/python/pipz/cli.py
@@ -96,11 +96,6 @@ def _install(opts, extra_args, tempdir):
         tell(e)
         exit(1)
 
-    packagesdir = opts.prefix or (
-        config.release_packages_path if opts.release
-        else config.local_packages_path
-    )
-
     with stage("Discovering existing packages... "):
         new, exists = list(), list()
         for dist in distributions:
@@ -116,6 +111,14 @@ def _install(opts, extra_args, tempdir):
                 tell("Please report the above traceback in full to "
                      "https://github.com/mottosso/rez-pipz/issues")
                 exit(1)
+
+            release_packages_path = (package.config.release_packages_path
+                                     or config.release_packages_path)
+            local_packages_path = (package.config.local_packages_path
+                                   or config.local_packages_path)
+            packagesdir = opts.prefix or (
+                release_packages_path if opts.release else local_packages_path
+            )
 
             if pip.exists(package, packagesdir):
                 exists.append(package)

--- a/python/pipz/pip.py
+++ b/python/pipz/pip.py
@@ -10,6 +10,7 @@ Algorithm:
 
 from rez.utils.logging_ import print_warning
 from rez.package_maker__ import PackageMaker
+from rez.developer_package import DeveloperPackage
 from rez.config import config
 from rez.vendor.six import six
 from rez.utils.platform_ import platform_
@@ -216,7 +217,8 @@ def convert(distribution, variants=None, dumb=False):
 
     requirements = _pip_to_rez_requirements(distribution)
 
-    maker = PackageMaker(_rez_name(distribution.project_name))
+    maker = PackageMaker(_rez_name(distribution.project_name),
+                         package_cls=DeveloperPackage)
     maker.version = distribution.version
 
     if requirements:
@@ -231,6 +233,14 @@ def convert(distribution, variants=None, dumb=False):
     ])
 
     package = maker.get_package()
+    data = maker._get_data()
+    data["pipz"] = True  # breadcrumb for preprocessing
+
+    # preprocessing
+    result = package._get_preprocessed(data)
+
+    if result:
+        package, data = result
 
     # Store reference for deployment
     distribution.dumb = dumb


### PR DESCRIPTION
Resolved #11 and now you can do some magic behind the scene.
Noted that I also added a flag `"pipz"` in `data` for identifying.
```python
# in rezconfig.py

def package_preprocess_function(this, data):
    from rez.config import config
    import os

    config_override = data.get("config", {})

    # Redirecting package deploy path
    if data.get("pipz"):
        # This change will be ignored if "--prefix" has set
        config_override["release_packages_path"] = os.path.join(
            config.release_packages_path, "ext-pipz"
        )

    data["config"] = config_override
```