### PR TITLE
Minor changes

### DIFF
--- a/install.py
+++ b/install.py
@@ -29,7 +29,7 @@ except ImportError:
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--overwrite", action="store_true")
-parser.add_argument("--pip", default="19.1.1")
+parser.add_argument("--pip", default="20.2b1")
 parser.add_argument("--wheel", default="0.33.4")
 parser.add_argument("--setuptools", default="41.0.1")
 parser.add_argument("--packaging", default="19.0")

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ tools = [
 # Upon a new release of pip, wheel or setuptools, this is what you edit
 build_command = " ".join([
     "python {root}/install.py ",
-    "--pip=19.1.1",
+    "--pip=20.2b1",
     "--wheel=0.33.4",
     "--setuptools=41.0.1",
     "--packaging=19.0",

--- a/package.py
+++ b/package.py
@@ -1,5 +1,5 @@
 name = "pipz"
-version = "1.2.0"
+version = "1.2.1"
 requires = ["bleeding_rez-2.29+", "python>=2,<4"]
 
 tools = [

--- a/python/pipz/version.py
+++ b/python/pipz/version.py
@@ -1,6 +1,6 @@
 
 try:
-    from __version__ import version
+    from .__version__ import version
 
 except ImportError:
     import os


### PR DESCRIPTION
* Bump `pip` install version to `20.2b1`

    I made this change because `PySide` wheel build failed on my MacOSX 10.15.5 with `pipz`, but I found that my system Python can install it successfully and it was using `pip==20.2b1`. So I re-install `rez-pipz` with this change and it's working now.

* Change to relative import `__version__`

    No problem if using `pipz` with Python 2, but if with Python 3, it gave me this :
    ```
    Traceback (most recent call last):
      File "/Users/davidlatwe/rez/install/pipz/1.2.0/default/python/pipz/version.py", line 3, in <module>
        from __version__ import version
    ModuleNotFoundError: No module named '__version__'
    ```