### PR TITLE
Bundle installation mode

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,5 +1,5 @@
 name = "pipz"
-version = "1.2.2"
+version = "1.3.0"
 requires = ["bleeding_rez-2.29+", "python>=2,<4"]
 
 tools = [

--- a/python/pipz/cli.py
+++ b/python/pipz/cli.py
@@ -85,6 +85,11 @@ def _install(opts, extra_args, tempdir):
     tell("Using pip-%s" % pip_version)
     tell("Using pipz-%s" % version)
 
+    as_bundle = bool(opts.bundle and int(os.getenv("REZ_BUILD_ENV", "0")))
+    rez_installing = bool(int(os.getenv("REZ_BUILD_INSTALL", "0")))
+    prefix = opts.prefix or ""
+    packagesdir = ""
+
     try:
         with stage("Reading package lists... "):
             distributions = pip.download(
@@ -116,14 +121,20 @@ def _install(opts, extra_args, tempdir):
                                      or config.release_packages_path)
             local_packages_path = (package.config.local_packages_path
                                    or config.local_packages_path)
-            packagesdir = opts.prefix or (
+            packagesdir = prefix or (
                 release_packages_path if opts.release else local_packages_path
             )
 
-            if pip.exists(package, packagesdir):
+            if not as_bundle and pip.exists(package, packagesdir):
                 exists.append(package)
             else:
                 new.append(package)
+
+    if as_bundle:
+        if rez_installing:
+            packagesdir = os.environ["REZ_BUILD_INSTALL_PATH"] + prefix
+        else:
+            packagesdir = os.environ["REZ_BUILD_PATH"] + prefix
 
     if not new:
         for package in exists:
@@ -171,7 +182,7 @@ def _install(opts, extra_args, tempdir):
     tell("Packages will be installed to %s" % packagesdir)
     tell("After this operation, %.2f mb will be used." % size)
 
-    if not opts.yes and not opts.quiet:
+    if not as_bundle and (not opts.yes and not opts.quiet):
         if not ask("Do you want to continue? [Y/n] "):
             print("Cancelled")
             return
@@ -186,7 +197,8 @@ def _install(opts, extra_args, tempdir):
         with stage(msg, timing=False):
             pip.deploy(
                 package,
-                path=packagesdir
+                path=packagesdir,
+                as_bundle=as_bundle,
             )
 
     tell("%d installed, %d skipped" % (len(new), len(exists)))
@@ -225,6 +237,11 @@ def main(argv=sys.argv):
         "install", nargs="+",
         help="Install the package")
     parser.add_argument(
+        "-b", "--bundle", action="store_true",
+        help="If enabled, and environment variable $REZ_BUILD_ENV is set, "
+             "all packages and their requirements will be deployed into "
+             "current Rez package build/install path.")
+    parser.add_argument(
         "--search", nargs="+",
         help="Search for the package on PyPi")
     parser.add_argument(
@@ -233,10 +250,15 @@ def main(argv=sys.argv):
         "locally only")
     parser.add_argument(
         "-va", "--variant", action="append",
-        help="Install package as variant, may be called multiple times.")
+        help="Install package as variant, may be called multiple times. "
+             "This option will be ignored if --bundle enabled and environment "
+             "variable $REZ_BUILD_ENV is set.")
     parser.add_argument(
         "-p", "--prefix", type=str, metavar="PATH",
-        help="Install to a custom package repository path.")
+        help="Install to a custom package repository path. If --bundle "
+             "enabled and environment variable $REZ_BUILD_ENV is set, "
+             "the --prefix will become the suffix of current Rez package "
+             "build/install path.")
     parser.add_argument(
         "-y", "--yes", action="store_true",
         help="Pre-emptively answer the question to continue")

--- a/python/pipz/cli.py
+++ b/python/pipz/cli.py
@@ -87,7 +87,6 @@ def _install(opts, extra_args, tempdir):
 
     as_bundle = bool(opts.bundle and int(os.getenv("REZ_BUILD_ENV", "0")))
     rez_installing = bool(int(os.getenv("REZ_BUILD_INSTALL", "0")))
-    prefix = opts.prefix or ""
     packagesdir = ""
 
     try:
@@ -121,7 +120,7 @@ def _install(opts, extra_args, tempdir):
                                      or config.release_packages_path)
             local_packages_path = (package.config.local_packages_path
                                    or config.local_packages_path)
-            packagesdir = prefix or (
+            packagesdir = opts.prefix or (
                 release_packages_path if opts.release else local_packages_path
             )
 
@@ -131,6 +130,7 @@ def _install(opts, extra_args, tempdir):
                 new.append(package)
 
     if as_bundle:
+        prefix = opts.prefix or ""
         if rez_installing:
             packagesdir = os.environ["REZ_BUILD_INSTALL_PATH"] + prefix
         else:


### PR DESCRIPTION
### New Feature - Bundle install

When building Rez package with `pipz`, presenting `--bundle` option in Rez package's `build_command` will make all PyPI packages and their requirements be installed in that Rez package.

That way, reproducing the build/release process of that Rez package is much easier. Plus, the result of this PyPI packages bundling would be just like making that Rez package as a portable Python virtual environment.

For example:

```python
# in package.py

name = "my_env"
version = "1.0"

pip_packages = [
    "pysftp==0.2.9",
    "pymongo",
]
private_build_requires = ["pipz"]
build_command = "install %s --bundle" % " ".join(pip_packages)

```

Also, I think this is a good workaround for #30.

Noted :
* `--bundle` option only works in Rez's package building session ($REZ_BUILD_ENV is set).
* Currently only available in command-line interface, `pip.install` not supported.
